### PR TITLE
small edit for the next page 

### DIFF
--- a/subtitle_dl.py
+++ b/subtitle_dl.py
@@ -131,8 +131,9 @@ def choose_subtitle(eng_srt):
         if chosen.upper() == 'S':
             os.system("clear||cls")
             search_srt()
-        if chosen.upper() == 'N':
-            if page_cntr >= page_max and page_max > 1:
+        if chosen.upper() == 'N' and page_max > 1:  
+            # Only change page if page_max is bigger than 1 (and chosen = 'N')
+            if page_cntr >= page_max:
                 page_cntr = 1
             else:
                 page_cntr = page_cntr + 1


### PR DESCRIPTION
I was doing some testing and noticed that with the old code if a movie had less then 50 subtitles (only 1 page) and you chose option 'N' it would try loading the next page only there wont be any results so i changed it slightly should fix it 

Before: https://gyazo.com/9c45138ebdf87bfb1a3f3118d3848199
After: https://gyazo.com/a7405ebb2885e52b04a3aa8e67b56f96

"Thor: Tales of Asgard" is the movie i used to test as it only has 35 subtitles total